### PR TITLE
Added fix for AdaFruit SD Card module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,6 @@ _autosave-*
 # Exported BOM files
 *.xml
 *.csv
+
+# MacOS Artifacts
+.DS_Store

--- a/firmware/Makefile
+++ b/firmware/Makefile
@@ -1,4 +1,4 @@
-# All build variables can be set on command line. Build with a 
+# All build variables can be set on command line. Build with a
 # command of this form:
 #
 #    TMS_BASE=0xBE SN76489_PORT=0xFF BOARD_REV=4 MSX_KEY_BASE=0xA9 PORT=/dev/tty.usbserial-00000000 make install
@@ -33,6 +33,9 @@
 
 # Base port for MSX keyboard
 # MSX_KEY_BASE=0xA9
+
+# SD Card Adapter - Set set 1 for the AdaFruit adapter, leave commented out for the Polulu adapter.
+# SD_CARD_ADAFRUIT = 1
 
 # Current git hash
 GITVERSION:= $(shell git log -1 --pretty='%h')
@@ -110,9 +113,12 @@ ifdef MSX_KEY_BASE
 	FEATURE_DEFINES += -DMSX_KEY_BASE=$(MSX_KEY_BASE)
 	OBJS += msxkey.o
 endif
+ifdef SD_CARD_ADAFRUIT
+	FEATURE_DEFINES += -DMISO_INPUT_PULLUP
+endif
 CFLAGS=-std=c99 -flto -Os $(FEATURE_DEFINES) -DF_CPU=$(F_CPU) -DGITVERSION="\"${GITVERSION}\"" -mmcu=$(MCU) -I.
 
-%.o: %.c
+%.o: %.c %.h
 	$(AVRCC) $(CFLAGS) $(LDFLAGS) -c -o $@ $<
 
 $(BIN).hex: $(BIN).elf

--- a/firmware/Makefile
+++ b/firmware/Makefile
@@ -116,9 +116,11 @@ endif
 ifdef SD_CARD_ADAFRUIT
 	FEATURE_DEFINES += -DMISO_INPUT_PULLUP
 endif
+
 CFLAGS=-std=c99 -flto -Os $(FEATURE_DEFINES) -DF_CPU=$(F_CPU) -DGITVERSION="\"${GITVERSION}\"" -mmcu=$(MCU) -I.
 
-%.o: %.c %.h
+
+%.o: %.c
 	$(AVRCC) $(CFLAGS) $(LDFLAGS) -c -o $@ $<
 
 $(BIN).hex: $(BIN).elf

--- a/firmware/spi.c
+++ b/firmware/spi.c
@@ -32,6 +32,9 @@ void spi_init(void)
 {
     SPI_DDR |= (1 << MOSI) | (1 << SCK) | CSADDRMASK;
     SPI_DDR &= ~(1 << MISO);
+#ifdef MISO_INPUT_PULLUP
+    MISO_HI;
+#endif
     SPSR = (1 << SPI2X);
     SPCR = (1 << SPE) | (1 << MSTR);
     SPI_FAST;

--- a/firmware/spi.h
+++ b/firmware/spi.h
@@ -35,9 +35,9 @@
 #define SPI_PORT PORTB
 #define SPI_PIN PINB
 
-#define SCK 7
-#define MISO 6
-#define MOSI 5
+#define SCK DDB7
+#define MISO DDB6
+#define MOSI DDB5
 
 #define IOX_ADDR 0
 #define SD_ADDR 1
@@ -61,11 +61,17 @@
 #define SPI_ENABLE SPCR |= (1 << SPE)
 #define SPI_DISABLE SPCR &= ~(1 << SPE)
 
-#define MISO_INPUT SPI_DDR &= ~(1 << MISO)
-#define MISO_OUTPUT SPI_DDR |= (1 << MISO)
 #define MISO_LO SPI_PORT &= ~(1 << MISO)
 #define MISO_HI SPI_PORT |= (1 << MISO)
 #define GET_MISO (SPI_PIN & (1 << MISO))
+#ifdef MISO_INPUT_PULLUP
+#define MISO_INPUT SPI_DDR &= ~(1 << MISO); MISO_HI;
+#define MISO_OUTPUT SPI_DDR |= (1 << MISO); MISO_LO;
+#else
+#define MISO_INPUT SPI_DDR &= ~(1 << MISO)
+#define MISO_OUTPUT SPI_DDR |= (1 << MISO)
+#endif
+
 
 #define SCK_LO SPI_PORT &= ~(1 << SCK)
 #define SCK_HI SPI_PORT |= (1 << SCK)


### PR DESCRIPTION
The Adafruit SD Card adapter doesn't have a level shifter on it data output line, thus per spec has a HIGH signal at 75% of 3.3V (~2.475V). This is not enough for the ATMAGA1248P to see a HIGH signal. Fortunately, we can configure the MISO input line on the ATMEGA1248P to apply an internal pull up resistor, which when activated, makes the Adafruit SD Card adapter work (so no hardware changes needed). 